### PR TITLE
fix: remove quotes in delim heredoc

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -297,6 +297,7 @@ void			append_redir(t_redir **head, t_redir_type type, char *filename);
 int				is_pipe_or_logical(t_token *token);
 int				is_redirect(t_token *token);
 int				get_size_args(t_token **token);
+int				have_quotes(char *raw);
 
 // debug functions
 void			print_env(t_env *env);

--- a/src/ast/ast_utils.c
+++ b/src/ast/ast_utils.c
@@ -65,3 +65,17 @@ int	get_size_args(t_token **token)
 	}
 	return (i);
 }
+
+int	have_quotes(char *raw)
+{
+	int	i;
+
+	i = 0;
+	while (raw[i])
+	{
+		if (raw[i] == '\'' || raw[i] == '\"')
+			return (1);
+		i++;
+	}
+	return (0);
+}

--- a/src/ast/commands_utils.c
+++ b/src/ast/commands_utils.c
@@ -55,8 +55,8 @@ char	*strip_quotes(char *raw, int *no_expand)
 		*no_expand = 1;
 		return (ft_substr(raw, 1, len - 2));
 	}
-	*no_expand = 0;
-	return (ft_strdup(raw));
+	*no_expand = have_quotes(raw);
+	return (rem_quotes(ft_strdup(raw), 0));
 }
 
 void	build_redir_list(t_redir **head, t_redir *node)


### PR DESCRIPTION
# fix/heredoc-quotes

- fix: remove quotes in delimiter heredoc, ex: cat <<  "E"OF